### PR TITLE
give i2c-* higher priority than ddc for i2c name candidates.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ fn get_i2c_dev(output: &str) -> Result<String> {
     let name = file_name.to_str().unwrap();
     if name.starts_with("i2c-") {
       dev = Some(name.to_owned());
+      break;
     } else if name == "ddc" {
       let link = entry.path().read_link().unwrap();
       dev = Some(link.file_name().unwrap().to_string_lossy().into_owned())


### PR DESCRIPTION
The i2c device name obtained from the ddc soft link and the one from the i2c-* directory may conflict. In my case, I found that the name from the i2c-* directory is correct using `ddcutil detect`. So I give higher priority to the one from the i2c-* directory.

```
╭─xiao@Rarch /sys/class/drm/card1-DP-2  
╰─➤  ll
.r--r--r-- 4.1k root 11 8月  13:58 connector_id
lrwxrwxrwx    - root 11 8月  13:58 ddc -> ../../../i2c-10/
lrwxrwxrwx    - root 11 8月  13:58 device -> ../../card1/
.r--r--r-- 4.1k root 11 8月  13:58 dpms
drwxr-xr-x    - root 11 8月  13:58 drm_dp_aux1/
.r--r--r--    0 root 11 8月  13:58 edid
.r--r--r-- 4.1k root 11 8月  13:58 enabled
drwxr-xr-x    - root 11 8月  13:58 i2c-15/
.r--r--r-- 4.1k root 11 8月  13:58 modes
drwxr-xr-x    - root 11 8月  13:58 power/
.rw-r--r-- 4.1k root 11 8月  13:58 status
lrwxrwxrwx    - root 11 8月  13:58 subsystem -> ../../../../../../../class/drm/
.rw-r--r-- 4.1k root 11 8月  13:58 uevent

```